### PR TITLE
Refactor global API from command objects to callbacks

### DIFF
--- a/packages/core/app/tests/window.test.ts
+++ b/packages/core/app/tests/window.test.ts
@@ -47,12 +47,7 @@ class FooWallet implements Wallet {
 declare const window: WalletsWindow;
 
 (async function () {
-    (window.navigator.wallets ||= []).push({
-        method: 'register',
-        wallets: [new FooWallet()],
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        callback() {},
-    });
+    (window.navigator.wallets ||= []).push(({ register }) => register(new FooWallet()));
 
     const wallets = initialize();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/core/standard/src/window.ts
+++ b/packages/core/standard/src/window.ts
@@ -10,22 +10,25 @@ export interface WalletsNavigator extends Navigator {
     wallets?: NavigatorWallets;
 }
 
-/** Global `window.navigator.wallets` object or command array. */
-export type NavigatorWallets = Wallets | WalletsCommand[];
+/** Global `window.navigator.wallets` object or callback array. */
+export type NavigatorWallets = WalletsCallback[] | Wallets;
+
+/**
+ * TODO: docs
+ */
+export type WalletsCallback = (wallets: Pick<Wallets, 'register'>) => void;
 
 /** Global `window.navigator.wallets` object API. */
 export interface Wallets {
     /**
      * TODO: docs
-     *
-     * @param commands TODO: docs
      */
-    push(...commands: ReadonlyArray<WalletsCommand>): void;
+    push(...callbacks: ReadonlyArray<WalletsCallback>): void;
 
     /**
      * TODO: docs
      */
-    register(wallets: ReadonlyArray<Wallet>): () => void;
+    register(...wallets: ReadonlyArray<Wallet>): () => void;
 
     /**
      * TODO: docs
@@ -38,47 +41,6 @@ export interface Wallets {
     on<E extends WalletsEventNames = WalletsEventNames>(event: E, listener: WalletsEvents[E]): () => void;
 }
 
-// TODO: `register` is the only command wallets need
-/** Global `window.navigator.wallets` command array item. */
-export type WalletsCommand = WalletsCommandRegister | WalletsCommandGet | WalletsCommandOn;
-
-/** Register wallets. This emits a `register` event. */
-export interface WalletsCommandRegister {
-    /** TODO: docs */
-    method: 'register';
-
-    /** Wallets to register. */
-    wallets: ReadonlyArray<Wallet>;
-
-    // TODO: consider making this optional
-    /** Function that will be called with a function to unregister the wallets. */
-    callback: (unregister: () => void) => void;
-}
-
-/** Get the wallets that have been registered. */
-export interface WalletsCommandGet {
-    /** TODO: docs */
-    method: 'get';
-
-    /** Function that will be called with all wallets that have been registered. */
-    callback: (wallets: ReadonlyArray<Wallet>) => void;
-}
-
-/** Add an event listener to subscribe to events. */
-export interface WalletsCommandOn<E extends WalletsEventNames = WalletsEventNames> {
-    /** TODO: docs */
-    method: 'on';
-
-    /** Event name to listen for. */
-    event: E;
-
-    /** Function that will be called when the event is emitted. */
-    listener: WalletsEvents[E];
-
-    /** Function that will be called with a function to remove the event listener and unsubscribe. */
-    callback: (off: () => void) => void;
-}
-
 /** Events emitted by the global `wallets` object. */
 export interface WalletsEvents {
     /**
@@ -86,14 +48,14 @@ export interface WalletsEvents {
      *
      * @param wallets Wallets that were registered.
      */
-    register(wallets: ReadonlyArray<Wallet>): void;
+    register(...wallets: ReadonlyArray<Wallet>): void;
 
     /**
      * Emitted when wallets are unregistered.
      *
      * @param wallets Wallets that were unregistered.
      */
-    unregister(wallets: ReadonlyArray<Wallet>): void;
+    unregister(...wallets: ReadonlyArray<Wallet>): void;
 }
 
 /** TODO: docs */

--- a/packages/example/wallets/src/window.ts
+++ b/packages/example/wallets/src/window.ts
@@ -7,47 +7,32 @@ declare const window: WalletsWindow;
 
 (function () {
     // The dapp hasn't loaded yet, so the first wallet to load gets or creates a queue, and registers itself on the window
-    (window.navigator.wallets ||= []).push({
-        method: 'register',
-        wallets: [new SolanaWallet()],
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        callback() {},
-    });
+    (window.navigator.wallets ||= []).push(({ register }) => register(new SolanaWallet()));
 
     // ... time passes, the dapp loads ...
 
-    // The dapp replaces the queue with a push function, and runs any queued commands
-    const { push } = initialize();
+    // The dapp replaces the queue with an object API, and runs any queued commands
+    const { get, on } = initialize();
 
-    // The dapp adds an event listener for new wallets that get registered after this point
-    push({
-        method: 'on',
-        event: 'register',
-        listener(wallets) {
-            // The dapp can add new wallets to its own state context as they are registered
-        },
-        callback(unsubscribe) {
-            // The dapp will receive the unsubscribe function when this runs, which it can later use to remove the listener
-        },
+    // The dapp gets all the wallets that have been registered so far, receiving all the registered wallets, which it
+    // can add to its own state context
+    let wallets = get();
+
+    // The dapp adds an event listener for new wallets that get registered after this point, receiving an unsubscribe
+    // function, which it can later use to remove the listener
+    const removeRegisterListener = on('register', function () {
+        // The dapp can add new wallets to its own state context as they are registered
+        wallets = get();
     });
 
-    // The dapp gets all the wallets that have been registered so far
-    push({
-        method: 'get',
-        callback(wallets) {
-            // The dapp will receive all the registered wallets when this runs, and can add them to its own state context
-        },
+    const removeUnregisterListener = on('unregister', function () {
+        wallets = get();
     });
 
     // ... time passes, other wallets load ...
 
     // The second wallet to load registers itself on the window
-    (window.navigator.wallets ||= []).push({
-        method: 'register',
-        wallets: [new EthereumWallet()],
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        callback() {},
-    });
+    (window.navigator.wallets ||= []).push(({ register }) => register(new EthereumWallet()));
 
     // The dapp has an event listener now, so it sees new wallets immediately and doesn't need to poll or list them again
     // This also works if the dapp loads before any wallets (it will initialize the push function, see no wallets on the first call, then see wallets as they load)

--- a/packages/solana/wallet-adapter/src/wallet.ts
+++ b/packages/solana/wallet-adapter/src/wallet.ts
@@ -285,7 +285,7 @@ export function registerWalletAdapter(
     endpoint?: string,
     match: (wallet: Wallet) => boolean = (wallet) => wallet.name === adapter.name
 ): () => void {
-    const wallets = initialize();
+    const { register, get, on } = initialize();
     const destructors: (() => void)[] = [];
 
     function destroy(): void {
@@ -295,7 +295,7 @@ export function registerWalletAdapter(
 
     function setup(): boolean {
         // If the adapter is unsupported, or a standard wallet that matches it has already been registered, do nothing.
-        if (adapter.readyState === WalletReadyState.Unsupported || wallets.get().some(match)) return true;
+        if (adapter.readyState === WalletReadyState.Unsupported || get().some(match)) return true;
 
         // If the adapter isn't ready, try again later.
         const ready =
@@ -304,10 +304,10 @@ export function registerWalletAdapter(
             const wallet = new SolanaWalletAdapterWallet(adapter, chain, endpoint);
             destructors.push(() => wallet.destroy());
             // Register the adapter wrapped as a standard wallet, and receive a function to unregister the adapter.
-            destructors.push(wallets.register([wallet]));
+            destructors.push(register(wallet));
             // Whenever a standard wallet is registered ...
             destructors.push(
-                wallets.on('register', (wallets) => {
+                on('register', (...wallets) => {
                     // ... check if it matches the adapter.
                     if (wallets.some(match)) {
                         // If it does, remove the event listener and unregister the adapter.

--- a/packages/wallets/backpack/src/index.ts
+++ b/packages/wallets/backpack/src/index.ts
@@ -4,11 +4,5 @@ import { BackpackSolanaWallet } from './wallet.js';
 declare const window: WalletsWindow;
 
 export function register(): void {
-    window.navigator.wallets = window.navigator.wallets || [];
-    window.navigator.wallets.push({
-        method: 'register',
-        wallets: [new BackpackSolanaWallet()],
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        callback() {},
-    });
+    (window.navigator.wallets ||= []).push(({ register }) => register(new BackpackSolanaWallet()));
 }

--- a/packages/wallets/backpack/src/wallet.ts
+++ b/packages/wallets/backpack/src/wallet.ts
@@ -18,8 +18,7 @@ import type { SolanaChain } from '@wallet-standard/util';
 import { bytesEqual, ReadonlyWalletAccount } from '@wallet-standard/util';
 import { decode } from 'bs58';
 import { icon } from './icon.js';
-import type { BackpackWindow } from './window.js';
-import type { Backpack } from './window.js';
+import type { Backpack, BackpackWindow } from './window.js';
 
 declare const window: BackpackWindow;
 

--- a/packages/wallets/glow/src/index.ts
+++ b/packages/wallets/glow/src/index.ts
@@ -4,11 +4,5 @@ import { GlowSolanaWallet } from './wallet.js';
 declare const window: WalletsWindow;
 
 export function register(): void {
-    window.navigator.wallets = window.navigator.wallets || [];
-    window.navigator.wallets.push({
-        method: 'register',
-        wallets: [new GlowSolanaWallet()],
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        callback() {},
-    });
+    (window.navigator.wallets ||= []).push(({ register }) => register(new GlowSolanaWallet()));
 }


### PR DESCRIPTION
Before:
```ts
(window.navigator.wallets ||= []).push({ method: 'register', wallets: [new StandardWallet()]);
```

After:
```ts
(window.navigator.wallets ||= []).push(({ register }) => register(new StandardWallet()));
```