### PR TITLE
fix: remove .js extension for .tsx files

### DIFF
--- a/packages/example/react/src/index.tsx
+++ b/packages/example/react/src/index.tsx
@@ -1,6 +1,6 @@
 import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
-import { App } from './App.js';
+import { App } from './App';
 
 ReactDOM.render(
     <StrictMode>

--- a/packages/example/solana-wallet-adapter/src/App.tsx
+++ b/packages/example/solana-wallet-adapter/src/App.tsx
@@ -7,9 +7,9 @@ import { clusterApiUrl } from '@solana/web3.js';
 import { useStandardWalletAdapters } from '@wallet-standard/solana-wallet-adapter-react';
 import type { FC, ReactNode } from 'react';
 import React, { useMemo } from 'react';
-import { RequestAirdrop } from './RequestAirdrop.js';
-import { SendTransaction } from './SendTransaction.js';
-import { SignMessage } from './SignMessage.js';
+import { RequestAirdrop } from './RequestAirdrop';
+import { SendTransaction } from './SendTransaction';
+import { SignMessage } from './SignMessage';
 
 export const App: FC = () => {
     return (

--- a/packages/example/solana-wallet-adapter/src/index.tsx
+++ b/packages/example/solana-wallet-adapter/src/index.tsx
@@ -1,6 +1,6 @@
 import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
-import { App } from './App.js';
+import { App } from './App';
 
 ReactDOM.render(
     <StrictMode>


### PR DESCRIPTION
## Summary

This PR fixes the build in the examples that use React, by removing the `.js` extension for `.tsx` file imports.

## Test Plan

- [x] `pnpm run build` succeeds