### PR TITLE
Refactor initialize and window.navigator.wallets

### DIFF
--- a/packages/core/app/src/initialize.ts
+++ b/packages/core/app/src/initialize.ts
@@ -1,4 +1,4 @@
-import type { Wallet, WalletsCallback, WalletsWindow, Wallets } from '@wallet-standard/standard';
+import type { Wallet, WalletsCallback, WalletsWindow } from '@wallet-standard/standard';
 
 declare const window: WalletsWindow;
 

--- a/packages/core/app/src/initialize.ts
+++ b/packages/core/app/src/initialize.ts
@@ -8,22 +8,22 @@ let initialized: InitializedWallets | undefined = undefined;
  * TODO: docs
  */
 export function initialize(): InitializedWallets {
-    // If it's already initialized by us, just return it.
+    // If it's already initialized by us, just return.
     if (initialized) return initialized;
-    // If we're not in a window (e.g. server-side rendering), initialize and return it.
+
+    // If we're not in a window (e.g. server-side rendering), initialize and return.
     if (typeof window === 'undefined') return (initialized = Object.freeze({ register, get, on }));
 
+    // Since we didn't initialize it, if it's not array, it was initialized externally, so throw an error.
     const wallets = (window.navigator.wallets ||= []);
+    if (!Array.isArray(wallets)) throw new Error('window.navigator.wallets was already initialized');
 
-    // If it's not initialized, initialize it and call all the wallet callbacks.
-    if (Array.isArray(wallets)) {
-        initialized = Object.freeze({ register, get, on });
-        Object.defineProperty(window.navigator, 'wallets', { value: Object.freeze({ push }) });
-        push(...wallets);
-    }
-    // If it's already initialized, and we didn't initialize it, throw an error.
-    else if (!initialized) throw new Error('window.navigator.wallets was already initialized');
+    // Initialize it and overwrite window.navigator.wallets with a non-writable API.
+    initialized = Object.freeze({ register, get, on });
+    Object.defineProperty(window.navigator, 'wallets', { value: Object.freeze({ push }) });
 
+    // Call all the wallet callbacks and return.
+    push(...wallets);
     return initialized;
 }
 

--- a/packages/core/app/src/initialize.ts
+++ b/packages/core/app/src/initialize.ts
@@ -1,73 +1,105 @@
-import type {
-    Wallet,
-    Wallets,
-    WalletsCallback,
-    WalletsEventNames,
-    WalletsEvents,
-    WalletsWindow,
-} from '@wallet-standard/standard';
+import type { Wallet, WalletsCallback, WalletsWindow, Wallets } from '@wallet-standard/standard';
 
 declare const window: WalletsWindow;
 
-/** TODO: docs */
-export function initialize(): Wallets {
-    if (typeof window === 'undefined') return create();
+let initialized: InitializedWallets | undefined = undefined;
 
-    const callbacks = (window.navigator.wallets ||= []);
-    // If it's already initialized, don't recreate it, just return it.
-    if (!Array.isArray(callbacks)) return callbacks;
+/**
+ * TODO: docs
+ */
+export function initialize(): InitializedWallets {
+    // If it's already initialized by us, just return it.
+    if (initialized) return initialized;
+    // If we're not in a window (e.g. server-side rendering), initialize and return it.
+    if (typeof window === 'undefined') return (initialized = Object.freeze({ register, get, on }));
 
-    const wallets = create();
-    Object.defineProperty(window.navigator, 'wallets', { value: wallets });
-    wallets.push(...callbacks);
-    return wallets;
+    const wallets = (window.navigator.wallets ||= []);
+
+    // If it's not initialized, initialize it and call all the wallet callbacks.
+    if (Array.isArray(wallets)) {
+        initialized = Object.freeze({ register, get, on });
+        Object.defineProperty(window.navigator, 'wallets', { value: Object.freeze({ push }) });
+        push(...wallets);
+    }
+    // If it's already initialized, and we didn't initialize it, throw an error.
+    else if (!initialized) throw new Error('window.navigator.wallets was already initialized');
+
+    return initialized;
 }
 
-function create(): Wallets {
-    const registered: Wallet[] = [];
-    const listeners: { [E in WalletsEventNames]?: WalletsEvents[E][] } = {};
+/** TODO: docs */
+export interface InitializedWallets {
+    /**
+     * TODO: docs
+     */
+    register(...wallets: ReadonlyArray<Wallet>): () => void;
 
-    function push(...callbacks: ReadonlyArray<WalletsCallback>): void {
-        for (const callback of callbacks) {
-            callback({ register });
-        }
+    /**
+     * TODO: docs
+     */
+    get(): ReadonlyArray<Wallet>;
+
+    /**
+     * TODO: docs
+     */
+    on<E extends WalletsEventNames = WalletsEventNames>(event: E, listener: WalletsEvents[E]): () => void;
+}
+
+/** Events emitted by the global `wallets` object. */
+export interface WalletsEvents {
+    /**
+     * Emitted when wallets are registered.
+     *
+     * @param wallets InitializedWallets that were registered.
+     */
+    register(...wallets: ReadonlyArray<Wallet>): void;
+
+    /**
+     * Emitted when wallets are unregistered.
+     *
+     * @param wallets InitializedWallets that were unregistered.
+     */
+    unregister(...wallets: ReadonlyArray<Wallet>): void;
+}
+
+/** TODO: docs */
+export type WalletsEventNames = keyof WalletsEvents;
+
+const registered = new Set<Wallet>();
+const listeners: { [E in WalletsEventNames]?: WalletsEvents[E][] } = {};
+
+function push(...callbacks: ReadonlyArray<WalletsCallback>): void {
+    for (const callback of callbacks) {
+        callback({ register });
     }
+}
 
-    function register(...wallets: ReadonlyArray<Wallet>): () => void {
-        // Filter out wallets that have already been registered.
-        // This prevents the same wallet from being registered twice, but it also prevents wallets from being
-        // unregistered by reusing a reference to the wallet to obtain the unregister function for it.
-        wallets = wallets.filter((wallet) => !registered.includes(wallet));
-        // If there are no new wallets to register, just return a no-op unregister function.
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        if (!wallets.length) return () => {};
+function register(...wallets: ReadonlyArray<Wallet>): () => void {
+    // Filter out wallets that have already been registered.
+    // This prevents the same wallet from being registered twice, but it also prevents wallets from being
+    // unregistered by reusing a reference to the wallet to obtain the unregister function for it.
+    wallets = wallets.filter((wallet) => !registered.has(wallet));
+    // If there are no new wallets to register, just return a no-op unregister function.
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    if (!wallets.length) return () => {};
 
-        registered.push(...wallets);
-        listeners['register']?.forEach((listener) => listener(...wallets));
-        // Return a function that unregisters the registered wallets.
-        return function unregister(): void {
-            wallets
-                .map((wallet) => registered.indexOf(wallet))
-                .filter((index) => index !== -1)
-                .sort()
-                .reverse()
-                .forEach((index) => registered.splice(index, 1));
-            listeners['unregister']?.forEach((listener) => listener(...wallets));
-        };
-    }
+    wallets.forEach((wallet) => registered.add(wallet));
+    listeners['register']?.forEach((listener) => listener(...wallets));
+    // Return a function that unregisters the registered wallets.
+    return function unregister(): void {
+        wallets.forEach((wallet) => registered.delete(wallet));
+        listeners['unregister']?.forEach((listener) => listener(...wallets));
+    };
+}
 
-    function get(): ReadonlyArray<Wallet> {
-        // Return a copy so the registered wallets can't be referenced or mutated.
-        return registered.slice();
-    }
+function get(): ReadonlyArray<Wallet> {
+    return [...registered];
+}
 
-    function on<E extends WalletsEventNames>(event: E, listener: WalletsEvents[E]): () => void {
-        listeners[event]?.push(listener) || (listeners[event] = [listener]);
-        // Return a function that removes the event listener.
-        return function off(): void {
-            listeners[event] = listeners[event]?.filter((existingListener) => listener !== existingListener);
-        };
-    }
-
-    return Object.freeze({ push, register, get, on });
+function on<E extends WalletsEventNames>(event: E, listener: WalletsEvents[E]): () => void {
+    listeners[event]?.push(listener) || (listeners[event] = [listener]);
+    // Return a function that removes the event listener.
+    return function off(): void {
+        listeners[event] = listeners[event]?.filter((existingListener) => listener !== existingListener);
+    };
 }

--- a/packages/core/react/src/WalletStandardProvider.tsx
+++ b/packages/core/react/src/WalletStandardProvider.tsx
@@ -7,8 +7,8 @@ import {
     SignTransactionProvider,
 } from './features/index.js';
 import { WalletAccountProvider } from './WalletAccountProvider.js';
-import { WalletsProvider } from './WalletsProvider.js';
 import { WalletProvider } from './WalletProvider.js';
+import { WalletsProvider } from './WalletsProvider.js';
 
 /** TODO: docs */
 export interface WalletStandardProviderProps {

--- a/packages/core/standard/src/wallet.ts
+++ b/packages/core/standard/src/wallet.ts
@@ -52,6 +52,7 @@ export interface Wallet {
      */
     readonly accounts: ReadonlyArray<WalletAccount>;
 
+    // TODO: think about moving events to features
     /**
      * Add an event listener to subscribe to events.
      *

--- a/packages/core/standard/src/wallet.ts
+++ b/packages/core/standard/src/wallet.ts
@@ -61,6 +61,8 @@ export interface Wallet {
      * @return Function to remove the event listener and unsubscribe.
      */
     on<E extends WalletEventNames>(event: E, listener: WalletEvents[E]): () => void;
+
+    // TODO: think about unregister/destructor
 }
 
 /** TODO: docs */

--- a/packages/core/standard/src/window.ts
+++ b/packages/core/standard/src/window.ts
@@ -1,62 +1,24 @@
 import type { Wallet } from './wallet.js';
 
-/** Global `window` containing a `navigator.wallets` object. */
+/** Global `window` containing a `navigator.wallets` interface. */
 export interface WalletsWindow extends Window {
     navigator: WalletsNavigator;
 }
 
-/** Global `window.navigator` containing a `wallets` object. */
+/** Global `window.navigator` containing a `wallets` interface. */
 export interface WalletsNavigator extends Navigator {
-    wallets?: NavigatorWallets;
+    wallets?: Wallets;
 }
 
-/** Global `window.navigator.wallets` object or callback array. */
-export type NavigatorWallets = WalletsCallback[] | Wallets;
-
-/**
- * TODO: docs
- */
-export type WalletsCallback = (wallets: Pick<Wallets, 'register'>) => void;
-
-/** Global `window.navigator.wallets` object API. */
+/** Global `window.navigator.wallets` interface. */
 export interface Wallets {
     /**
      * TODO: docs
      */
     push(...callbacks: ReadonlyArray<WalletsCallback>): void;
-
-    /**
-     * TODO: docs
-     */
-    register(...wallets: ReadonlyArray<Wallet>): () => void;
-
-    /**
-     * TODO: docs
-     */
-    get(): ReadonlyArray<Wallet>;
-
-    /**
-     * TODO: docs
-     */
-    on<E extends WalletsEventNames = WalletsEventNames>(event: E, listener: WalletsEvents[E]): () => void;
 }
 
-/** Events emitted by the global `wallets` object. */
-export interface WalletsEvents {
-    /**
-     * Emitted when wallets are registered.
-     *
-     * @param wallets Wallets that were registered.
-     */
-    register(...wallets: ReadonlyArray<Wallet>): void;
-
-    /**
-     * Emitted when wallets are unregistered.
-     *
-     * @param wallets Wallets that were unregistered.
-     */
-    unregister(...wallets: ReadonlyArray<Wallet>): void;
-}
-
-/** TODO: docs */
-export type WalletsEventNames = keyof WalletsEvents;
+/**
+ * TODO: docs
+ */
+export type WalletsCallback = (wallets: { register(...wallets: ReadonlyArray<Wallet>): () => void }) => void;


### PR DESCRIPTION
After discussion with @steveluscher, we can simplify the global `window.navigator.wallets` interface and (lightly) harden a dapp against external initialization of that interface. Wallets shouldn't be able to call any method but `push` and dapps shouldn't trust the global object if they see it's not an array.