### PR TITLE
Add disconnect feature

### DIFF
--- a/packages/core/features/src/disconnect.ts
+++ b/packages/core/features/src/disconnect.ts
@@ -1,0 +1,20 @@
+/** TODO: docs */
+export type DisconnectFeature = {
+    /** Namespace for the feature. */
+    'standard:disconnect': {
+        // TODO: think about removing feature versions
+        /** Version of the feature API. */
+        version: DisconnectVersion;
+
+        /**
+         * Disconnect from the wallet.
+         */
+        disconnect: DisconnectMethod;
+    };
+};
+
+/** TODO: docs */
+export type DisconnectVersion = '1.0.0';
+
+/** TODO: docs */
+export type DisconnectMethod = () => Promise<void>;

--- a/packages/core/features/src/disconnect.ts
+++ b/packages/core/features/src/disconnect.ts
@@ -1,4 +1,9 @@
-/** TODO: docs */
+/**
+ * The disconnect feature is an optional feature that may be implemented by
+ * wallets to perform any cleanup-related work.
+ * This feature may not be invoked by dapps and should not be depended on.
+ * This feature should not remove any permissions previously granted through ConnectFeature.
+ */
 export type DisconnectFeature = {
     /** Namespace for the feature. */
     'standard:disconnect': {

--- a/packages/core/features/src/index.ts
+++ b/packages/core/features/src/index.ts
@@ -1,5 +1,6 @@
 import type { WalletWithFeatures } from '@wallet-standard/standard';
 import type { ConnectFeature } from './connect.js';
+import type { DisconnectFeature } from './disconnect.js';
 import type { EventsFeature } from './events.js';
 import type { SignAndSendTransactionFeature } from './signAndSendTransaction.js';
 import type { SignMessageFeature } from './signMessage.js';
@@ -8,6 +9,7 @@ import type { SignTransactionFeature } from './signTransaction.js';
 /** TODO: docs */
 export type StandardFeatures =
     | ConnectFeature
+    | DisconnectFeature
     | EventsFeature
     | SignAndSendTransactionFeature
     | SignMessageFeature
@@ -17,6 +19,7 @@ export type StandardFeatures =
 export type WalletWithStandardFeatures = WalletWithFeatures<StandardFeatures>;
 
 export * from './connect.js';
+export * from './disconnect.js';
 export * from './events.js';
 export * from './signAndSendTransaction.js';
 export * from './signMessage.js';


### PR DESCRIPTION
There have been some requests by partners to implement a disconnect feature. In general, our guidance will be that partners should not necessarily use this feature, and should instead implement their wallets in a way such that this feature is not needed. However, some wallets will need this feature to easily onboard, so adding it seems low risk.

This feature is completely optional, and is also not guaranteed to be called at all.