### PR TITLE
fix connect logic in example dapp

### DIFF
--- a/packages/example/dapp/src/pages/Connect.tsx
+++ b/packages/example/dapp/src/pages/Connect.tsx
@@ -20,10 +20,10 @@ export const Connect: FC = () => {
             }
         }
 
-        if (wallet && !isConnected) {
+        if (wallet && connect && !isConnected) {
             connectOrDeselect();
         }
-    }, [wallet, isConnected, connect, setWallet]);
+    }, [wallet, connect, isConnected, setWallet]);
 
     if (isConnected) {
         return <Navigate to="/" replace={true} />;


### PR DESCRIPTION
The `connect` function is defined as a side-effect after the wallet is set (calling `setWallet`), so we need to wait for it to be defined.