### PR TITLE
Prevent `WalletsContext.Provider` from rerendering when `wallets` does not change

### DIFF
--- a/.changeset/quiet-spiders-doubt.md
+++ b/.changeset/quiet-spiders-doubt.md
@@ -1,0 +1,5 @@
+---
+"@wallet-standard/react-core": patch
+---
+
+Prevent `WalletsContext.Provider` from rerendering when `wallets` does not change. Fewer spurious rerenders means better performance.

--- a/packages/react/core/src/WalletsProvider.tsx
+++ b/packages/react/core/src/WalletsProvider.tsx
@@ -33,5 +33,9 @@ export const WalletsProvider: FC<WalletsProviderProps> = ({ children }) => {
         return () => destructors.forEach((destroy) => destroy());
     }, [get, on]);
 
-    return <WalletsContext.Provider value={{ wallets }}>{children}</WalletsContext.Provider>;
+    const contextValue = useMemo(() => ({
+        wallets,
+    }), [wallets]);
+
+    return <WalletsContext.Provider value={contextValue}>{children}</WalletsContext.Provider>;
 };


### PR DESCRIPTION
`value={{/* ... */}}` results in the entire context provider re-rendering every time, even if the properties in the context don't change.