### PR TITLE
Export reusable feature names

### DIFF
--- a/.changeset/forty-roses-reply.md
+++ b/.changeset/forty-roses-reply.md
@@ -1,0 +1,5 @@
+---
+'@wallet-standard/features': patch
+---
+
+Export reusable feature name constants

--- a/packages/core/features/src/connect.ts
+++ b/packages/core/features/src/connect.ts
@@ -1,5 +1,8 @@
 import type { WalletAccount } from '@wallet-standard/base';
 
+/** Name of the feature. */
+export const Connect = 'standard:connect';
+
 /**
  * `standard:connect` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
  * {@link "@wallet-standard/base".Wallet} to allow the app to obtain authorization to use
@@ -9,7 +12,7 @@ import type { WalletAccount } from '@wallet-standard/base';
  */
 export type ConnectFeature = {
     /** Name of the feature. */
-    readonly 'standard:connect': {
+    readonly [Connect]: {
         /** Version of the feature implemented by the Wallet. */
         readonly version: ConnectVersion;
         /** Method to call to use the feature. */

--- a/packages/core/features/src/disconnect.ts
+++ b/packages/core/features/src/disconnect.ts
@@ -1,3 +1,6 @@
+/** Name of the feature. */
+export const Disconnect = 'standard:disconnect';
+
 /**
  * `standard:disconnect` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
  * {@link "@wallet-standard/base".Wallet} to allow the app to perform any cleanup work.
@@ -10,7 +13,7 @@
  */
 export type DisconnectFeature = {
     /** Name of the feature. */
-    readonly 'standard:disconnect': {
+    readonly [Disconnect]: {
         /** Version of the feature implemented by the Wallet. */
         readonly version: DisconnectVersion;
         /** Method to call to use the feature. */

--- a/packages/core/features/src/events.ts
+++ b/packages/core/features/src/events.ts
@@ -1,5 +1,8 @@
 import type { Wallet } from '@wallet-standard/base';
 
+/** Name of the feature. */
+export const Events = 'standard:events';
+
 /**
  * `standard:events` is a {@link "@wallet-standard/base".Wallet.features | feature} that may be implemented by a
  * {@link "@wallet-standard/base".Wallet} to allow the app to add an event listener and subscribe to events emitted by
@@ -9,7 +12,7 @@ import type { Wallet } from '@wallet-standard/base';
  */
 export type EventsFeature = {
     /** Name of the feature. */
-    readonly 'standard:events': {
+    readonly [Events]: {
         /** Version of the feature implemented by the {@link "@wallet-standard/base".Wallet}. */
         readonly version: EventsVersion;
         /** Method to call to use the feature. */


### PR DESCRIPTION
Apps and wallets needing to feature detect with strings like `if ("standard:connect") in wallet.features` is verbose and error prone. Exporting and using these feature names as constant strings will help.