### PR TITLE
Convert Solana Ed25519 Keypairs for Use in TweetNaCl Box Encryption

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "name": "Wallet Standard",
+    "name": "walletstandard",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/wallet-standard/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/example/wallets/package.json
+++ b/packages/example/wallets/package.json
@@ -25,6 +25,7 @@
         "@wallet-standard/ethereum": "workspace:^",
         "@wallet-standard/experimental": "workspace:^",
         "bs58": "^4.0.1",
+        "ed2curve": "^0.3.0",
         "ethers": "^5.7.2",
         "tweetnacl": "^1.0.3"
     },


### PR DESCRIPTION
Solana utilizes Ed25519 keypairs for its signing mechanism. While these keypairs are useful for signing and verifying transactions, they are not directly compatible with the TweetNaCl.js library for asymmetric encryption (box) due to differences in the underlying cryptographic schemes.

By leveraging the ed2curve-js library, we can convert the Ed25519 keys to Curve25519 keys, which are compatible with the TweetNaCl.js box encryption functions and made for Diffie Helmann exchange. This would allow wallets to utilize their Solana keypairs for encryption and decryption without needing to generate separate encryption keys.

If adding an additonal dependency causes a problem to a wallet's maintainers, ed2curve conversion can also be done using only tweetnacl.

Please review the changes and let me know if there are any concerns or suggestions for improvement.
c/ @jordansexton 