### PR TITLE
`get()` now returns the same array object unless the wallets have changed

### DIFF
--- a/.changeset/fifty-crews-boil.md
+++ b/.changeset/fifty-crews-boil.md
@@ -1,0 +1,5 @@
+---
+"@wallet-standard/app": patch
+---
+
+`Wallets::get()` now returns the same array object unless the wallets have changed, to make downstream optimizations based on `===` possible.

--- a/packages/core/app/src/wallets.ts
+++ b/packages/core/app/src/wallets.ts
@@ -8,7 +8,15 @@ import type {
 } from '@wallet-standard/base';
 
 let wallets: Wallets | undefined = undefined;
-const registered = new Set<Wallet>();
+const registeredWalletsSet = new Set<Wallet>();
+function addRegisteredWallet(wallet: Wallet) {
+    _cachedWalletsArray = undefined;
+    registeredWalletsSet.add(wallet);
+}
+function removeRegisteredWallet(wallet: Wallet) {
+    _cachedWalletsArray = undefined;
+    registeredWalletsSet.delete(wallet);
+}
 const listeners: { [E in WalletsEventNames]?: WalletsEventsListeners[E][] } = {};
 
 /**
@@ -136,22 +144,26 @@ function register(...wallets: Wallet[]): () => void {
     // Filter out wallets that have already been registered.
     // This prevents the same wallet from being registered twice, but it also prevents wallets from being
     // unregistered by reusing a reference to the wallet to obtain the unregister function for it.
-    wallets = wallets.filter((wallet) => !registered.has(wallet));
+    wallets = wallets.filter((wallet) => !registeredWalletsSet.has(wallet));
     // If there are no new wallets to register, just return a no-op unregister function.
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     if (!wallets.length) return () => {};
 
-    wallets.forEach((wallet) => registered.add(wallet));
+    wallets.forEach((wallet) => addRegisteredWallet(wallet));
     listeners['register']?.forEach((listener) => guard(() => listener(...wallets)));
     // Return a function that unregisters the registered wallets.
     return function unregister(): void {
-        wallets.forEach((wallet) => registered.delete(wallet));
+        wallets.forEach((wallet) => removeRegisteredWallet(wallet));
         listeners['unregister']?.forEach((listener) => guard(() => listener(...wallets)));
     };
 }
 
+let _cachedWalletsArray: readonly Wallet[] | undefined;
 function get(): readonly Wallet[] {
-    return [...registered];
+    if (!_cachedWalletsArray) {
+        _cachedWalletsArray = [...registeredWalletsSet];
+    }
+    return _cachedWalletsArray;
 }
 
 function on<E extends WalletsEventNames>(event: E, listener: WalletsEventsListeners[E]): () => void {

--- a/packages/core/app/src/wallets.ts
+++ b/packages/core/app/src/wallets.ts
@@ -10,11 +10,11 @@ import type {
 let wallets: Wallets | undefined = undefined;
 const registeredWalletsSet = new Set<Wallet>();
 function addRegisteredWallet(wallet: Wallet) {
-    _cachedWalletsArray = undefined;
+    cachedWalletsArray = undefined;
     registeredWalletsSet.add(wallet);
 }
 function removeRegisteredWallet(wallet: Wallet) {
-    _cachedWalletsArray = undefined;
+    cachedWalletsArray = undefined;
     registeredWalletsSet.delete(wallet);
 }
 const listeners: { [E in WalletsEventNames]?: WalletsEventsListeners[E][] } = {};
@@ -158,12 +158,12 @@ function register(...wallets: Wallet[]): () => void {
     };
 }
 
-let _cachedWalletsArray: readonly Wallet[] | undefined;
+let cachedWalletsArray: readonly Wallet[] | undefined;
 function get(): readonly Wallet[] {
-    if (!_cachedWalletsArray) {
-        _cachedWalletsArray = [...registeredWalletsSet];
+    if (!cachedWalletsArray) {
+        cachedWalletsArray = [...registeredWalletsSet];
     }
-    return _cachedWalletsArray;
+    return cachedWalletsArray;
 }
 
 function on<E extends WalletsEventNames>(event: E, listener: WalletsEventsListeners[E]): () => void {


### PR DESCRIPTION
# Summary

This is important for the next PR in this stack. Returning the same array from this getter if the wallets haven't change unlocks opportunities to memoize downstream code.

# Test plan

```shell
cd packages/examples/react
pnpm start
open http://localhost:1234
```

Observed the example app load and find my browser's wallets.
