### PR TITLE
Reimplement the `useWallets()` hook with `useSyncExternalStore`

### DIFF
--- a/.changeset/fifty-crews-boil.md
+++ b/.changeset/fifty-crews-boil.md
@@ -1,0 +1,5 @@
+---
+"@wallet-standard/app": patch
+---
+
+`Wallets::get()` now returns the same array object unless the wallets have changed, to make downstream optimizations based on `===` possible.

--- a/.changeset/late-gorillas-run.md
+++ b/.changeset/late-gorillas-run.md
@@ -1,0 +1,5 @@
+---
+"@wallet-standard/react-core": patch
+---
+
+Reimplement the `useWallets()` hook with `useSyncExternalStore`

--- a/packages/core/app/src/wallets.ts
+++ b/packages/core/app/src/wallets.ts
@@ -8,7 +8,15 @@ import type {
 } from '@wallet-standard/base';
 
 let wallets: Wallets | undefined = undefined;
-const registered = new Set<Wallet>();
+const registeredWalletsSet = new Set<Wallet>();
+function addRegisteredWallet(wallet: Wallet) {
+    _cachedWalletsArray = undefined;
+    registeredWalletsSet.add(wallet);
+}
+function removeRegisteredWallet(wallet: Wallet) {
+    _cachedWalletsArray = undefined;
+    registeredWalletsSet.delete(wallet);
+}
 const listeners: { [E in WalletsEventNames]?: WalletsEventsListeners[E][] } = {};
 
 /**
@@ -136,22 +144,26 @@ function register(...wallets: Wallet[]): () => void {
     // Filter out wallets that have already been registered.
     // This prevents the same wallet from being registered twice, but it also prevents wallets from being
     // unregistered by reusing a reference to the wallet to obtain the unregister function for it.
-    wallets = wallets.filter((wallet) => !registered.has(wallet));
+    wallets = wallets.filter((wallet) => !registeredWalletsSet.has(wallet));
     // If there are no new wallets to register, just return a no-op unregister function.
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     if (!wallets.length) return () => {};
 
-    wallets.forEach((wallet) => registered.add(wallet));
+    wallets.forEach((wallet) => addRegisteredWallet(wallet));
     listeners['register']?.forEach((listener) => guard(() => listener(...wallets)));
     // Return a function that unregisters the registered wallets.
     return function unregister(): void {
-        wallets.forEach((wallet) => registered.delete(wallet));
+        wallets.forEach((wallet) => removeRegisteredWallet(wallet));
         listeners['unregister']?.forEach((listener) => guard(() => listener(...wallets)));
     };
 }
 
+let _cachedWalletsArray: readonly Wallet[] | undefined;
 function get(): readonly Wallet[] {
-    return [...registered];
+    if (!_cachedWalletsArray) {
+        _cachedWalletsArray = [...registeredWalletsSet];
+    }
+    return _cachedWalletsArray;
 }
 
 function on<E extends WalletsEventNames>(event: E, listener: WalletsEventsListeners[E]): () => void {

--- a/packages/core/app/src/wallets.ts
+++ b/packages/core/app/src/wallets.ts
@@ -10,11 +10,11 @@ import type {
 let wallets: Wallets | undefined = undefined;
 const registeredWalletsSet = new Set<Wallet>();
 function addRegisteredWallet(wallet: Wallet) {
-    _cachedWalletsArray = undefined;
+    cachedWalletsArray = undefined;
     registeredWalletsSet.add(wallet);
 }
 function removeRegisteredWallet(wallet: Wallet) {
-    _cachedWalletsArray = undefined;
+    cachedWalletsArray = undefined;
     registeredWalletsSet.delete(wallet);
 }
 const listeners: { [E in WalletsEventNames]?: WalletsEventsListeners[E][] } = {};
@@ -158,12 +158,12 @@ function register(...wallets: Wallet[]): () => void {
     };
 }
 
-let _cachedWalletsArray: readonly Wallet[] | undefined;
+let cachedWalletsArray: readonly Wallet[] | undefined;
 function get(): readonly Wallet[] {
-    if (!_cachedWalletsArray) {
-        _cachedWalletsArray = [...registeredWalletsSet];
+    if (!cachedWalletsArray) {
+        cachedWalletsArray = [...registeredWalletsSet];
     }
-    return _cachedWalletsArray;
+    return cachedWalletsArray;
 }
 
 function on<E extends WalletsEventNames>(event: E, listener: WalletsEventsListeners[E]): () => void {

--- a/packages/react/core/package.json
+++ b/packages/react/core/package.json
@@ -30,8 +30,8 @@
         "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json"
     },
     "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
+        "react": ">=18",
+        "react-dom": ">=18"
     },
     "dependencies": {
         "@wallet-standard/app": "workspace:^",

--- a/packages/react/core/src/useStable.ts
+++ b/packages/react/core/src/useStable.ts
@@ -1,0 +1,11 @@
+import { useRef } from 'react';
+
+const UNRESOLVED = Symbol();
+
+export function useStable<T>(getValue: () => T): T {
+    const ref = useRef<T | typeof UNRESOLVED>(UNRESOLVED);
+    if (ref.current === UNRESOLVED) {
+        ref.current = getValue();
+    }
+    return ref.current;
+}

--- a/packages/react/core/src/useWallets.ts
+++ b/packages/react/core/src/useWallets.ts
@@ -1,31 +1,25 @@
 import { getWallets } from '@wallet-standard/app';
 import type { Wallet } from '@wallet-standard/base';
-import { useMemo, useState, useEffect } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
+import { useStable } from './useStable.js';
+
+function getServerSnapshot(): readonly Wallet[] {
+    return [];
+}
 
 /** TODO: docs */
 export function useWallets(): readonly Wallet[] {
-    // Initialize `window.navigator.wallets` and obtain a synchronous API.
-    const { get, on } = useMemo(() => getWallets(), []);
-
-    // Synchronously get the wallets that have registered already so that they can be accessed on the first render.
-    const [wallets, setWallets] = useState(() => get());
-
-    useEffect(() => {
-        const destructors: (() => void)[] = [];
-
-        // TODO: figure out if this can ever actually happen
-        // FIXME: this can definitely happen, refactor similar to @solana/wallet-standard-wallet-adapter-react
-        // Get and set the wallets that have been registered already, in case they changed since the state initializer.
-        setWallets(get());
-
-        // Add an event listener to add any wallets that are registered after this point.
-        destructors.push(on('register', () => setWallets(get())));
-
-        // Add an event listener to remove any wallets that are unregistered after this point.
-        destructors.push(on('unregister', () => setWallets(get())));
-
-        return () => destructors.forEach((destroy) => destroy());
-    }, [get, on]);
-
-    return wallets;
+    const { get: getSnapshot, on } = useStable(getWallets);
+    const subscribe = useCallback(
+        (callback: () => void) => {
+            const disposeRegisterListener = on('register', callback);
+            const disposeUnregisterListener = on('unregister', callback);
+            return () => {
+                disposeRegisterListener();
+                disposeUnregisterListener();
+            };
+        },
+        [on]
+    );
+    return useSyncExternalStore<readonly Wallet[]>(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
# Summary

Take a look at the `TODO` that was eliminated in this PR. It indicated a (real) worry that a wallet could register between the time that you got the initial list and the time that the subscriptions were set up.

This PR introduces the solution for this. The `useSyncExternalStore()` hook in React 18 is designed for exactly this scenario: needing to immediately subscribe to some event(s) after having taken a snapshot of some external state.

> [!NOTE]
> This increases the requirements for this code to `react@>=18`. If it becomes crucial to run this in an older version of React we could investigate releasing a version of `@wallet-standard/react` that uses [the shim](https://www.npmjs.com/package/use-sync-external-store).

# Test plan

```shell
cd packages/examples/react
pnpm start
open http://localhost:1234
```

Observed the example app load and find my browser's wallets.
