### PR TITLE
fix: intersect types of features when construction feature catalogs

### DIFF
--- a/packages/core/app/tests/window.test.ts
+++ b/packages/core/app/tests/window.test.ts
@@ -17,7 +17,7 @@ class FooWalletAccount implements WalletAccount {
     address = '';
     publicKey = new Uint8Array();
     chains = ['foo:mainnet'] as const;
-    features: readonly (keyof FooSignTransactionFeature | keyof FooSignMessageFeature)[] = [
+    features: readonly (keyof (FooSignTransactionFeature & FooSignMessageFeature))[] = [
         'foo:signTransaction',
         'foo:signMessage',
     ] as const;

--- a/packages/core/features/src/index.ts
+++ b/packages/core/features/src/index.ts
@@ -9,7 +9,7 @@ import type { StandardEventsFeature } from './events.js';
  *
  * @group Features
  */
-export type StandardFeatures = StandardConnectFeature | StandardDisconnectFeature | StandardEventsFeature;
+export type StandardFeatures = StandardConnectFeature & StandardDisconnectFeature & StandardEventsFeature;
 
 /**
  * Type alias for a {@link "@wallet-standard/base".Wallet} that implements some or all {@link StandardFeatures}.

--- a/packages/experimental/features/src/index.ts
+++ b/packages/experimental/features/src/index.ts
@@ -6,12 +6,11 @@ import type { SignMessageFeature } from './signMessage.js';
 import type { SignTransactionFeature } from './signTransaction.js';
 
 /** TODO: docs */
-export type ExperimentalFeatures =
-    | DecryptFeature
-    | EncryptFeature
-    | SignAndSendTransactionFeature
-    | SignMessageFeature
-    | SignTransactionFeature;
+export type ExperimentalFeatures = DecryptFeature &
+    EncryptFeature &
+    SignAndSendTransactionFeature &
+    SignMessageFeature &
+    SignTransactionFeature;
 
 /** TODO: docs */
 export type WalletWithExperimentalFeatures = WalletWithFeatures<ExperimentalFeatures>;


### PR DESCRIPTION
While these were unions, TypeScript could not enumerate all of the possibilities.

With this change, you can now do things like this:

<img width="797" alt="image" src="https://github.com/wallet-standard/wallet-standard/assets/13243/4560c6f1-b077-46b2-a138-28c6c6878eb1">
