### PR TITLE
fix: cache the empty wallet array when rendering on the server in React

### DIFF
--- a/packages/react/core/src/useWallets.ts
+++ b/packages/react/core/src/useWallets.ts
@@ -3,8 +3,10 @@ import type { Wallet } from '@wallet-standard/base';
 import { useCallback, useSyncExternalStore } from 'react';
 import { useStable } from './useStable.js';
 
+const NO_WALLETS: readonly Wallet[] = [];
+
 function getServerSnapshot(): readonly Wallet[] {
-    return [];
+    return NO_WALLETS;
 }
 
 /** TODO: docs */


### PR DESCRIPTION
This will prevent the following error when rendering in a server-components environment (eg. Next.js).

```
useWallets.ts:24 Warning: The result of getServerSnapshot should be cached to avoid an infinite loop
```