### PR TITLE
Add equality check for `WalletAccount`

### DIFF
--- a/packages/core/wallet/src/util.ts
+++ b/packages/core/wallet/src/util.ts
@@ -185,7 +185,13 @@ export interface Indexed<T> {
  *
  * @group Util
  */
-export function walletAccountsEqual(a: WalletAccount, b: WalletAccount): boolean {
+export function walletAccountsEqual(a?: WalletAccount, b?: WalletAccount): boolean {
+    if (!a && !b) {
+        return true;
+    }
+    if (!a || !b) {
+        return false;
+    }
     return (
         a.address === b.address &&
         bytesEqual(a.publicKey, b.publicKey) &&

--- a/packages/core/wallet/src/util.ts
+++ b/packages/core/wallet/src/util.ts
@@ -67,17 +67,6 @@ export class ReadonlyWalletAccount implements WalletAccount {
         this.#label = account.label;
         this.#icon = account.icon;
     }
-
-    public equals(other: ReadonlyWalletAccount): boolean {
-        return (
-            this.address === other.address &&
-            arraysEqual(this.publicKey, other.publicKey) &&
-            arraysEqual(this.chains, other.chains) &&
-            arraysEqual(this.features, other.features) &&
-            this.label === other.label &&
-            this.icon === other.icon
-        );
-    }
 }
 
 /**
@@ -184,4 +173,25 @@ export function guard(callback: () => void) {
 export interface Indexed<T> {
     length: number;
     [index: number]: T;
+}
+
+/**
+ * Compare WalletAccounts, using {@link arraysEqual} on the array fields
+ *
+ * @param a A WalletAccount.
+ * @param b Another WalletAccount.
+ *
+ * @return `true` if WalletAccount has exactly the same fields via a deep equality check
+ *
+ * @group Util
+ */
+export function walletAccountsEqual(a: WalletAccount, b: WalletAccount): boolean {
+    return (
+        a.address === b.address &&
+        bytesEqual(a.publicKey, b.publicKey) &&
+        arraysEqual(a.chains, b.chains) &&
+        arraysEqual(a.features, b.features) &&
+        a.label === b.label &&
+        a.icon === b.icon
+    );
 }

--- a/packages/core/wallet/src/util.ts
+++ b/packages/core/wallet/src/util.ts
@@ -67,6 +67,17 @@ export class ReadonlyWalletAccount implements WalletAccount {
         this.#label = account.label;
         this.#icon = account.icon;
     }
+
+    public equals(other: ReadonlyWalletAccount): boolean {
+        return (
+            this.address === other.address &&
+            arraysEqual(this.publicKey, other.publicKey) &&
+            arraysEqual(this.chains, other.chains) &&
+            arraysEqual(this.features, other.features) &&
+            this.label === other.label &&
+            this.icon === other.icon
+        );
+    }
 }
 
 /**


### PR DESCRIPTION
## Add equality check for `WalletAccount`

We use equality checks on the `WalletAccount` in the solana wallet-standard repo, e.g.: https://github.com/anza-xyz/wallet-standard/blob/0739a2afb3c3ac1f2e380137ccfa051c4b303cbd/packages/wallet-adapter/base/src/wallet.ts#L329

The problem there so far has been that that ends up being a reference equality check, and it's not always the same reference, but might have the same values. Giving us an equals function here to use instead.