### PR TITLE
A common implementation for asserting on features

### DIFF
--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -27,7 +27,8 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json"
+        "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
+        "test": "jest -c ../../../node_modules/@wallet-standard/test-config/jest.config.ts --rootDir . --silent"
     },
     "dependencies": {
         "@wallet-standard/base": "workspace:^"

--- a/packages/core/features/src/__tests__/assertions-test.ts
+++ b/packages/core/features/src/__tests__/assertions-test.ts
@@ -1,0 +1,75 @@
+import { getFeatureAssertionFunction, getFeatureGuardFunction } from '../assertions.js';
+
+const Bar = 'bar:feature' as const;
+const Foo = 'foo:feature' as const;
+type Features = {
+    [Bar]: {
+        doBar(): void;
+    };
+    [Foo]: {
+        doFoo(): void;
+    };
+};
+
+describe('getFeatureGuardFunction()', () => {
+    it('returns a function that returns `false` when the input is missing the specified feature', () => {
+        const objectHasBarFeature: ReturnType<typeof getFeatureGuardFunction<Features, typeof Bar>> =
+            getFeatureGuardFunction(Bar);
+        expect(objectHasBarFeature({ features: {} })).toBe(false);
+    });
+    it('returns a function that returns `true` when its input has the specified feature', () => {
+        const objectHasFooFeature: ReturnType<typeof getFeatureGuardFunction<Features, typeof Foo>> =
+            getFeatureGuardFunction(Foo);
+        expect(
+            objectHasFooFeature({
+                features: {
+                    [Foo]: {
+                        doFoo() {
+                            /* empty */
+                        },
+                    },
+                },
+            })
+        ).toBe(true);
+    });
+});
+
+describe('getFeatureAssertionFunction()', () => {
+    it('returns a function that throws when a address-having input is missing the specified feature', () => {
+        const assertObjectHasBarFeature: ReturnType<typeof getFeatureAssertionFunction<Features, typeof Bar>> =
+            getFeatureAssertionFunction(Bar);
+        expect(() => {
+            assertObjectHasBarFeature({ address: 'ABC', features: {} });
+        }).toThrow(`The \`${Bar}\` feature is not supported by the address \`ABC\``);
+    });
+    it('returns a function that throws when a address-and-label-having input is missing the specified feature', () => {
+        const assertObjectHasBarFeature: ReturnType<typeof getFeatureAssertionFunction<Features, typeof Bar>> =
+            getFeatureAssertionFunction(Bar);
+        expect(() => {
+            assertObjectHasBarFeature({ address: 'ABC', features: {}, label: 'Mock Label' });
+        }).toThrow(`The \`${Bar}\` feature is not supported by the address \`ABC\` (Mock Label)`);
+    });
+    it('returns a function that throws when a name-having input is missing the specified feature', () => {
+        const assertObjectHasBarFeature: ReturnType<typeof getFeatureAssertionFunction<Features, typeof Bar>> =
+            getFeatureAssertionFunction(Bar);
+        expect(() => {
+            assertObjectHasBarFeature({ features: {}, name: 'Mock Name' });
+        }).toThrow(`The \`${Bar}\` feature is not supported by the wallet 'Mock Name'`);
+    });
+    it('returns a function that does not throw when its input has the specified feature', () => {
+        const assertObjectHasFooFeature: ReturnType<typeof getFeatureAssertionFunction<Features, typeof Foo>> =
+            getFeatureAssertionFunction(Foo);
+        expect(() => {
+            assertObjectHasFooFeature({
+                features: {
+                    [Foo]: {
+                        doFoo() {
+                            /* empty */
+                        },
+                    },
+                },
+                name: 'Mock Wallet',
+            });
+        }).not.toThrow();
+    });
+});

--- a/packages/core/features/src/__typetests__/assertions-typetests.ts
+++ b/packages/core/features/src/__typetests__/assertions-typetests.ts
@@ -1,0 +1,56 @@
+import { getFeatureAssertionFunction, getFeatureGuardFunction } from '../assertions.js';
+
+// [DESCRIBE] getFeatureGuardFunction.
+{
+    // It expands the existing features type of an object when the feature is found
+    {
+        const obj = null as unknown as { features: { 'bar:feature': { doBar(): boolean } } };
+        const objectHasFooFeature: ReturnType<
+            typeof getFeatureGuardFunction<{ 'foo:feature': { doFoo: () => void } }, 'foo:feature'>
+        > = getFeatureGuardFunction('foo:feature');
+        if (objectHasFooFeature(obj)) {
+            obj.features['bar:feature'].doBar();
+            obj.features['foo:feature'].doFoo();
+        }
+    }
+    // It keeps the existing features type of the object the same when the feature is not found
+    {
+        const obj = null as unknown as { features: { 'bar:feature': { doBar(): boolean } } };
+        const objectHasFooFeature: ReturnType<
+            typeof getFeatureGuardFunction<{ 'foo:feature': { doFoo: () => void } }, 'foo:feature'>
+        > = getFeatureGuardFunction('foo:feature');
+        if (!objectHasFooFeature(obj)) {
+            obj.features['bar:feature'].doBar();
+            // @ts-expect-error
+            obj.features['foo:feature'].doFoo();
+        }
+    }
+}
+
+// [DESCRIBE] getFeatureAssertionFunction.
+{
+    // It expands the existing features type of an object when the feature is found
+    {
+        const obj = null as unknown as { features: { 'bar:feature': { doBar(): boolean } }; name: string };
+        const assertObjectHasFooFeature: ReturnType<
+            typeof getFeatureAssertionFunction<{ 'foo:feature': { doFoo: () => void } }, 'foo:feature'>
+        > = getFeatureAssertionFunction('foo:feature');
+        assertObjectHasFooFeature(obj);
+        obj.features['bar:feature'].doBar();
+        obj.features['foo:feature'].doFoo();
+    }
+    // It keeps the existing features type of the object the same when the feature is not found
+    {
+        const obj = null as unknown as { features: { 'bar:feature': { doBar(): boolean } }; name: string };
+        const assertObjectHasFooFeature: ReturnType<
+            typeof getFeatureAssertionFunction<{ 'foo:feature': { doFoo: () => void } }, 'foo:feature'>
+        > = getFeatureAssertionFunction('foo:feature');
+        try {
+            assertObjectHasFooFeature(obj);
+        } catch {
+            obj.features['bar:feature'].doBar();
+            // @ts-expect-error
+            obj.features['foo:feature'].doFoo();
+        }
+    }
+}

--- a/packages/core/features/src/assertions.ts
+++ b/packages/core/features/src/assertions.ts
@@ -1,0 +1,57 @@
+import type { IdentifierString } from '@wallet-standard/base';
+
+type NamedObject =
+    // Typically `WalletAccounts`
+    | {
+          address: string;
+          label?: string;
+      }
+    // Typically `Wallets`
+    | {
+          name: string;
+      };
+type NamedObjectWithFeatures = NamedObject & ObjectWithFeatures;
+type ObjectWithFeatures = {
+    features: Record<IdentifierString, unknown>;
+};
+
+export function getFeatureGuardFunction<
+    TFeature extends Record<IdentifierString, unknown>,
+    TFeatureName extends IdentifierString
+>(featureName: TFeatureName) {
+    return function objectHasFeature(object: ObjectWithFeatures): object is { features: Pick<TFeature, TFeatureName> } {
+        return featureName in object.features;
+    };
+}
+
+/**
+ * In order to make use of the assertion this produces, you need to recast it to an assertion
+ * function, like this:
+ *
+ *   const assertWalletHasConnectFeature: ReturnType<
+ *     typeof getFeatureAssertionFunction<StandardConnectFeature, typeof StandardConnect>
+ *   > = getFeatureAssertionFunction(StandardConnect);
+ *
+ * Read more about why, here: https://github.com/microsoft/TypeScript/issues/36931
+ */
+export function getFeatureAssertionFunction<
+    TFeature extends Record<IdentifierString, unknown>,
+    TFeatureName extends IdentifierString
+>(featureName: TFeatureName) {
+    const objectHasFeature = getFeatureGuardFunction<TFeature, TFeatureName>(featureName);
+    return function assertObjectHasFeature(
+        object: NamedObjectWithFeatures
+    ): asserts object is typeof object & { features: Pick<TFeature, TFeatureName> } {
+        if (!objectHasFeature(object)) {
+            const objectName =
+                'address' in object
+                    ? `the address \`${object.address}\`${object.label ? ` (${object.label})` : ''}`
+                    : `the wallet '${object.name}'`;
+            const err = new Error(`The \`${featureName}\` feature is not supported by ${objectName}`);
+            if ('captureStackTrace' in Error) {
+                Error.captureStackTrace(err, assertObjectHasFeature);
+            }
+            throw err;
+        }
+    };
+}

--- a/packages/core/features/src/index.ts
+++ b/packages/core/features/src/index.ts
@@ -18,6 +18,7 @@ export type StandardFeatures = StandardConnectFeature | StandardDisconnectFeatur
  */
 export type WalletWithStandardFeatures = WalletWithFeatures<StandardFeatures>;
 
+export * from './assertions.js';
 export * from './connect.js';
 export * from './disconnect.js';
 export * from './events.js';

--- a/packages/react/core/src/WalletProvider.tsx
+++ b/packages/react/core/src/WalletProvider.tsx
@@ -1,5 +1,6 @@
 import type { Wallet } from '@wallet-standard/base';
-import type { EventsFeature } from '@wallet-standard/features';
+import type { StandardEventsFeature } from '@wallet-standard/features';
+import { getFeatureGuardFunction, StandardEvents } from '@wallet-standard/features';
 import type { FC, ReactNode } from 'react';
 import React, { useEffect, useState } from 'react';
 import { getWalletProperties, WalletContext } from './useWallet.js';
@@ -10,9 +11,9 @@ export interface WalletProviderProps {
 }
 
 /** TODO: docs */
-export function hasEventsFeature(features: Wallet['features']): features is EventsFeature {
-    return 'standard:events' in features;
-}
+export const hasEventsFeature: ReturnType<
+    typeof getFeatureGuardFunction<StandardEventsFeature, typeof StandardEvents>
+> = /*#__PURE__*/ getFeatureGuardFunction(StandardEvents);
 
 /** TODO: docs */
 export const WalletProvider: FC<WalletProviderProps> = ({ children }) => {
@@ -26,11 +27,11 @@ export const WalletProvider: FC<WalletProviderProps> = ({ children }) => {
 
     // When the features change, listen for property changes if the wallet supports it.
     useEffect(() => {
-        if (hasEventsFeature(features))
-            return features['standard:events'].on('change', (properties) =>
+        if (wallet && hasEventsFeature(wallet))
+            return wallet.features[StandardEvents].on('change', (properties) =>
                 setWalletProperties((currentProperties) => ({ ...currentProperties, ...properties }))
             );
-    }, [features]);
+    }, [wallet]);
 
     return (
         <WalletContext.Provider

--- a/packages/react/core/src/useWallets.ts
+++ b/packages/react/core/src/useWallets.ts
@@ -1,19 +1,16 @@
 import { getWallets } from '@wallet-standard/app';
 import type { Wallet, WalletWithFeatures } from '@wallet-standard/base';
-import { StandardEvents, type StandardEventsFeature } from '@wallet-standard/features';
 import { useCallback, useRef, useSyncExternalStore } from 'react';
 
 import { hasEventsFeature } from './WalletProvider.js';
 import { useStable } from './useStable.js';
+import type { StandardEventsFeature } from '@wallet-standard/features';
+import { StandardEvents } from '@wallet-standard/features';
 
 const NO_WALLETS: readonly Wallet[] = [];
 
 function getServerSnapshot(): readonly Wallet[] {
     return NO_WALLETS;
-}
-
-function walletHasStandardEventsFeature(wallet: Wallet): wallet is WalletWithFeatures<StandardEventsFeature> {
-    return hasEventsFeature(wallet.features);
 }
 
 /** TODO: docs */
@@ -34,21 +31,22 @@ export function useWallets(): readonly Wallet[] {
         (onStoreChange: () => void) => {
             const disposeRegisterListener = on('register', onStoreChange);
             const disposeUnregisterListener = on('unregister', onStoreChange);
-            const disposeWalletChangeListeners = get()
-                .filter(walletHasStandardEventsFeature)
-                .map((wallet) =>
-                    wallet.features[StandardEvents].on('change', () => {
-                        // Despite a change in a property of a wallet, the array that contains the
-                        // list of wallets will be reused. The wallets array before and after the
-                        // change will be referentially equal.
-                        //
-                        // Here, we force a new wallets array wrapper to be created by cloning the
-                        // array. This gives React the signal to re-render, because it will notice
-                        // that the return value of `getSnapshot()` has changed.
-                        outputWallets.current = [...get()];
-                        onStoreChange();
-                    })
-                );
+            const walletsWithStandardEventsFeature = get().filter(
+                hasEventsFeature
+            ) as WalletWithFeatures<StandardEventsFeature>[];
+            const disposeWalletChangeListeners = walletsWithStandardEventsFeature.map((wallet) =>
+                wallet.features[StandardEvents].on('change', () => {
+                    // Despite a change in a property of a wallet, the array that contains the
+                    // list of wallets will be reused. The wallets array before and after the
+                    // change will be referentially equal.
+                    //
+                    // Here, we force a new wallets array wrapper to be created by cloning the
+                    // array. This gives React the signal to re-render, because it will notice
+                    // that the return value of `getSnapshot()` has changed.
+                    outputWallets.current = [...get()];
+                    onStoreChange();
+                })
+            );
             return () => {
                 disposeRegisterListener();
                 disposeUnregisterListener();


### PR DESCRIPTION
Given an object with a name/address/label, this function factory creates assertion functions that throw if a feature is unavailable, and refine the type otherwise. In this way, we can define the assertion `Error` once, and use it everywhere.