### PR TITLE
fix: prevent undefined disposal function

### DIFF
--- a/packages/react/core/src/useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT.ts
+++ b/packages/react/core/src/useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT.ts
@@ -41,8 +41,15 @@ export function useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT(): readonly Wallet[] {
                     outputWallets.current = [...get()];
                     onStoreChange();
                 });
-                walletsToChangeListenerDisposeFn.set(wallet, dispose);
-                return dispose;
+
+                // Some wallet has StandardEvents but the event registering doesn't return
+                // a disposal function
+                if (typeof dispose === 'function') {
+                    walletsToChangeListenerDisposeFn.set(wallet, dispose);
+                    return dispose;
+                }
+
+                return () => {};
             }
             const disposeRegisterListener = on('register', (...wallets) => {
                 wallets.filter(walletHasStandardEventsFeature).map(subscribeToWalletEvents);


### PR DESCRIPTION
I have integrated the `@wallet-standard/react` and discovered that some wallets do not return a disposal/cleanup function when handling changes to StandardEvents. This causes `walletsToChangeListenerDisposeFn.forEach((d) => d());` to throw an error (`d is not a function`) and break the app. Checking the type of this function helps prevent the error.