### PR TITLE
v1.1.0

### DIFF
--- a/.changeset/every-shoes-notice.md
+++ b/.changeset/every-shoes-notice.md
@@ -1,0 +1,7 @@
+---
+'@wallet-standard/ui-features': patch
+'@wallet-standard/react-core': patch
+'@wallet-standard/ui-compare': patch
+---
+
+Patch changes to support latest Wallet Standard version

--- a/.changeset/six-turtles-feel.md
+++ b/.changeset/six-turtles-feel.md
@@ -1,0 +1,7 @@
+---
+'@wallet-standard/features': minor
+'@wallet-standard/base': minor
+---
+
+- `WalletIcon` now supports HTTP/S URLs
+- The `standard:connect` feature now supports filtering addresses, chains, and features.

--- a/packages/core/base/src/wallet.ts
+++ b/packages/core/base/src/wallet.ts
@@ -13,7 +13,30 @@ import type { IdentifierArray, IdentifierRecord, IdentifierString } from './iden
  *
  * @group Wallet
  */
-export type WalletVersion = '1.0.0';
+export type WalletVersion = WalletVersion1_0_0 | WalletVersion1_1_0;
+
+/**
+ * Initial version of the Wallet Standard.
+ *
+ * @group Wallet
+ */
+export type WalletVersion1_0_0 = '1.0.0';
+
+/**
+ * Version of the Wallet Standard that supports HTTP/S URLs for icons.
+ *
+ * @group Wallet
+ */
+export type WalletVersion1_1_0 = '1.1.0';
+
+/**
+ * Icon of a {@link Wallet} or {@link WalletAccount}.
+ *
+ * @group Wallet
+ */
+export type WalletIcon<V extends WalletVersion = WalletVersion1_0_0> = V extends WalletVersion1_1_0
+    ? WalletIcon1_1_0
+    : WalletIcon1_0_0;
 
 /**
  * A data URI containing a base64-encoded SVG, WebP, PNG, or GIF image.
@@ -22,7 +45,16 @@ export type WalletVersion = '1.0.0';
  *
  * @group Wallet
  */
-export type WalletIcon = `data:image/${'svg+xml' | 'webp' | 'png' | 'gif'};base64,${string}`;
+export type WalletIcon1_0_0 = `data:image/${'svg+xml' | 'webp' | 'png' | 'gif'};base64,${string}`;
+
+/**
+ * An HTTP/S URL, or data URI containing a base64-encoded SVG, WebP, PNG, or GIF image.
+ *
+ * Used by {@link Wallet.icon | Wallet::icon} and {@link WalletAccount.icon | WalletAccount::icon}.
+ *
+ * @group Wallet
+ */
+export type WalletIcon1_1_0 = `https://${string}` | `http://${string}` | WalletIcon1_0_0;
 
 /**
  * Interface of a **Wallet**, also referred to as a **Standard Wallet**.
@@ -31,13 +63,13 @@ export type WalletIcon = `data:image/${'svg+xml' | 'webp' | 'png' | 'gif'};base6
  *
  * @group Wallet
  */
-export interface Wallet {
+export interface Wallet<V extends WalletVersion = WalletVersion1_0_0> {
     /**
      * {@link WalletVersion | Version} of the Wallet Standard implemented by the Wallet.
      *
      * Must be read-only, static, and canonically defined by the Wallet Standard.
      */
-    readonly version: WalletVersion;
+    readonly version: V;
 
     /**
      * Name of the Wallet. This may be displayed by the app.
@@ -51,7 +83,7 @@ export interface Wallet {
      *
      * Must be read-only, static, and canonically defined by the wallet extension or application.
      */
-    readonly icon: WalletIcon;
+    readonly icon: WalletIcon<V>;
 
     /**
      * Chains supported by the Wallet.
@@ -112,7 +144,7 @@ export interface Wallet {
      * The {@link "@wallet-standard/features".EventsFeature | `standard:events` feature} should be used to notify the
      * app if the value changes.
      */
-    readonly accounts: readonly WalletAccount[];
+    readonly accounts: readonly WalletAccount<V>[];
 }
 
 /**
@@ -128,7 +160,7 @@ export interface Wallet {
  *
  * @group Wallet
  */
-export interface WalletAccount {
+export interface WalletAccount<V extends WalletVersion = WalletVersion1_0_0> {
     /** Address of the account, corresponding with a public key. */
     readonly address: string;
 
@@ -153,7 +185,7 @@ export interface WalletAccount {
     readonly label?: string;
 
     /** Optional user-friendly icon for the account. This may be displayed by the app. */
-    readonly icon?: WalletIcon;
+    readonly icon?: WalletIcon<V>;
 }
 
 /**

--- a/packages/core/features/src/connect.ts
+++ b/packages/core/features/src/connect.ts
@@ -125,7 +125,7 @@ export type ConnectInput<V extends StandardConnectVersion = StandardConnectVersi
  *
  * @group Connect
  */
-export interface StandardConnectOutput<V extends StandardConnectVersion = StandardConnectVersion1_1_0> {
+export interface StandardConnectOutput<V extends StandardConnectVersion = StandardConnectVersion1_0_0> {
     /** List of accounts in the {@link "@wallet-standard/base".Wallet} that the app has been authorized to use. */
     readonly accounts: readonly WalletAccount<
         V extends StandardConnectVersion1_1_0 ? WalletVersion1_1_0 : WalletVersion1_0_0

--- a/packages/core/features/src/connect.ts
+++ b/packages/core/features/src/connect.ts
@@ -1,4 +1,4 @@
-import type { WalletAccount } from '@wallet-standard/base';
+import type { WalletAccount, WalletVersion1_0_0, WalletVersion1_1_0 } from '@wallet-standard/base';
 
 /** Name of the feature. */
 export const StandardConnect = 'standard:connect';
@@ -16,13 +16,13 @@ export const Connect = StandardConnect;
  *
  * @group Connect
  */
-export type StandardConnectFeature = {
+export type StandardConnectFeature<V extends StandardConnectVersion = StandardConnectVersion1_0_0> = {
     /** Name of the feature. */
     readonly [StandardConnect]: {
         /** Version of the feature implemented by the Wallet. */
-        readonly version: StandardConnectVersion;
+        readonly version: V;
         /** Method to call to use the feature. */
-        readonly connect: StandardConnectMethod;
+        readonly connect: StandardConnectMethod<V>;
     };
 };
 /**
@@ -30,14 +30,29 @@ export type StandardConnectFeature = {
  *
  * @group Deprecated
  */
-export type ConnectFeature = StandardConnectFeature;
+export type ConnectFeature<V extends StandardConnectVersion = StandardConnectVersion1_0_0> = StandardConnectFeature<V>;
 
 /**
  * Version of the {@link StandardConnectFeature} implemented by a {@link "@wallet-standard/base".Wallet}.
  *
  * @group Connect
  */
-export type StandardConnectVersion = '1.0.0';
+export type StandardConnectVersion = StandardConnectVersion1_0_0 | StandardConnectVersion1_1_0;
+
+/**
+ * Initial version of the {@link StandardConnectFeature}.
+ *
+ * @group Connect
+ */
+export type StandardConnectVersion1_0_0 = '1.0.0';
+
+/**
+ * Version of the {@link StandardConnectFeature} that supports filtering addresses, chains, and features, and supports HTTP/S URLs for account icons.
+ *
+ * @group Connect
+ */
+export type StandardConnectVersion1_1_0 = '1.1.0';
+
 /**
  * @deprecated Use {@link StandardConnectVersion} instead.
  *
@@ -50,49 +65,75 @@ export type ConnectVersion = StandardConnectVersion;
  *
  * @group Connect
  */
-export type StandardConnectMethod = (input?: StandardConnectInput) => Promise<StandardConnectOutput>;
+export type StandardConnectMethod<V extends StandardConnectVersion = StandardConnectVersion1_0_0> = (
+    input?: StandardConnectInput<V>
+) => Promise<StandardConnectOutput<V>>;
 /**
  * @deprecated Use {@link StandardConnectMethod} instead.
  *
  * @group Deprecated
  */
-export type ConnectMethod = StandardConnectMethod;
+export type ConnectMethod<V extends StandardConnectVersion = StandardConnectVersion1_0_0> = StandardConnectMethod<V>;
 
 /**
  * Input for the {@link StandardConnectMethod}.
  *
  * @group Connect
  */
-export interface StandardConnectInput {
+export type StandardConnectInput<V extends StandardConnectVersion = StandardConnectVersion1_0_0> = {
     /**
-     * By default, using the {@link StandardConnectFeature} should prompt the user to request authorization to accounts.
-     * Set the `silent` flag to `true` to request accounts that have already been authorized without prompting.
+     * @deprecated
      *
-     * This flag may or may not be used by the Wallet and the app should not depend on it being used.
-     * If this flag is used by the Wallet, the Wallet should not prompt the user, and should return only the accounts
-     * that the app is authorized to use.
+     * This flag should not be used by the app, and it must have no effect on the Wallet's behavior.
      */
     readonly silent?: boolean;
-}
+} & V extends StandardConnectVersion1_1_0
+    ? {
+          /**
+           * List of account {@link "@wallet-standard/base".WalletAccount.address addresses} that the app is requesting authorization to use.
+           * If provided, the Wallet must return *only* accounts with *any* of the provided addresses.
+           */
+          readonly addresses?: WalletAccount<
+              V extends StandardConnectVersion1_1_0 ? WalletVersion1_1_0 : WalletVersion1_0_0
+          >['address'][];
+          /**
+           * List of account {@link "@wallet-standard/base".WalletAccount.chains chains} that the app is requesting authorization to use.
+           * If provided, the Wallet must return *only* accounts with *any* of the provided chains.
+           */
+          readonly chains?: WalletAccount<
+              V extends StandardConnectVersion1_1_0 ? WalletVersion1_1_0 : WalletVersion1_0_0
+          >['chains'];
+          /**
+           * List of account {@link "@wallet-standard/base".WalletAccount.features features} that the app is requesting authorization to use.
+           * If provided, the Wallet must return *only* accounts with *any* of the provided features.
+           */
+          readonly features?: WalletAccount<
+              V extends StandardConnectVersion1_1_0 ? WalletVersion1_1_0 : WalletVersion1_0_0
+          >['features'];
+      }
+    : Record<string, never>;
+
 /**
  * @deprecated Use {@link StandardConnectInput} instead.
  *
  * @group Deprecated
  */
-export type ConnectInput = StandardConnectInput;
+export type ConnectInput<V extends StandardConnectVersion = StandardConnectVersion1_0_0> = StandardConnectInput<V>;
 
 /**
  * Output of the {@link StandardConnectMethod}.
  *
  * @group Connect
  */
-export interface StandardConnectOutput {
+export interface StandardConnectOutput<V extends StandardConnectVersion = StandardConnectVersion1_1_0> {
     /** List of accounts in the {@link "@wallet-standard/base".Wallet} that the app has been authorized to use. */
-    readonly accounts: readonly WalletAccount[];
+    readonly accounts: readonly WalletAccount<
+        V extends StandardConnectVersion1_1_0 ? WalletVersion1_1_0 : WalletVersion1_0_0
+    >[];
 }
 /**
  * @deprecated Use {@link StandardConnectOutput} instead.
  *
  * @group Deprecated
  */
-export type ConnectOutput = StandardConnectOutput;
+export type ConnectOutput<V extends StandardConnectVersion = StandardConnectVersion1_0_0> = StandardConnectOutput<V>;

--- a/packages/core/features/src/events.ts
+++ b/packages/core/features/src/events.ts
@@ -1,4 +1,4 @@
-import type { Wallet } from '@wallet-standard/base';
+import type { Wallet, WalletVersion1_0_0, WalletVersion1_1_0 } from '@wallet-standard/base';
 
 /** Name of the feature. */
 export const StandardEvents = 'standard:events';
@@ -16,13 +16,13 @@ export const Events = StandardEvents;
  *
  * @group Events
  */
-export type StandardEventsFeature = {
+export type StandardEventsFeature<V extends StandardEventsVersion = StandardEventsVersion1_0_0> = {
     /** Name of the feature. */
     readonly [StandardEvents]: {
         /** Version of the feature implemented by the {@link "@wallet-standard/base".Wallet}. */
-        readonly version: StandardEventsVersion;
+        readonly version: V;
         /** Method to call to use the feature. */
-        readonly on: StandardEventsOnMethod;
+        readonly on: StandardEventsOnMethod<V>;
     };
 };
 /**
@@ -37,7 +37,22 @@ export type EventsFeature = StandardEventsFeature;
  *
  * @group Events
  */
-export type StandardEventsVersion = '1.0.0';
+export type StandardEventsVersion = StandardEventsVersion1_0_0 | StandardEventsVersion1_1_0;
+
+/**
+ * Initial version of the {@link StandardEventsFeature}.
+ *
+ * @group Events
+ */
+export type StandardEventsVersion1_0_0 = '1.0.0';
+
+/**
+ * Version of the {@link StandardEventsFeature} that supports HTTP/S URLs for account icons.
+ *
+ * @group Events
+ */
+export type StandardEventsVersion1_1_0 = '1.1.0';
+
 /**
  * @deprecated Use {@link StandardEventsVersion} instead.
  *
@@ -58,37 +73,39 @@ export type EventsVersion = StandardEventsVersion;
  *
  * @group Events
  */
-export type StandardEventsOnMethod = <E extends StandardEventsNames>(
+export type StandardEventsOnMethod<V extends StandardEventsVersion = StandardEventsVersion1_0_0> = <
+    E extends StandardEventsNames,
+>(
     event: E,
-    listener: StandardEventsListeners[E]
+    listener: StandardEventsListeners<V>[E]
 ) => () => void;
 /**
  * @deprecated Use {@link StandardEventsOnMethod} instead.
  *
  * @group Deprecated
  */
-export type EventsOnMethod = StandardEventsOnMethod;
+export type EventsOnMethod<V extends StandardEventsVersion = StandardEventsVersion1_0_0> = StandardEventsOnMethod<V>;
 
 /**
  * Types of event listeners of the {@link StandardEventsFeature}.
  *
  * @group Events
  */
-export interface StandardEventsListeners {
+export interface StandardEventsListeners<V extends StandardEventsVersion = StandardEventsVersion1_0_0> {
     /**
      * Listener that will be called when {@link StandardEventsChangeProperties | properties} of the
      * {@link "@wallet-standard/base".Wallet} have changed.
      *
      * @param properties Properties that changed with their **new** values.
      */
-    change(properties: StandardEventsChangeProperties): void;
+    change(properties: StandardEventsChangeProperties<V>): void;
 }
 /**
  * @deprecated Use {@link StandardEventsListeners} instead.
  *
  * @group Deprecated
  */
-export type EventsListeners = StandardEventsListeners;
+export type EventsListeners<V extends StandardEventsVersion = StandardEventsVersion1_0_0> = StandardEventsListeners<V>;
 
 /**
  * Names of {@link StandardEventsListeners} that can be listened for.
@@ -109,7 +126,7 @@ export type EventsNames = StandardEventsNames;
  *
  * @group Events
  */
-export interface StandardEventsChangeProperties {
+export interface StandardEventsChangeProperties<V extends StandardEventsVersion = StandardEventsVersion1_0_0> {
     /**
      * {@link "@wallet-standard/base".Wallet.chains | Chains} supported by the Wallet.
      *
@@ -133,11 +150,14 @@ export interface StandardEventsChangeProperties {
      *
      * The value must be the **new** value of the property.
      */
-    readonly accounts?: Wallet['accounts'];
+    readonly accounts?: Wallet<
+        V extends StandardEventsVersion1_1_0 ? WalletVersion1_1_0 : WalletVersion1_0_0
+    >['accounts'];
 }
 /**
  * @deprecated Use {@link StandardEventsChangeProperties} instead.
  *
  * @group Deprecated
  */
-export type EventsChangeProperties = StandardEventsChangeProperties;
+export type EventsChangeProperties<V extends StandardEventsVersion = StandardEventsVersion1_0_0> =
+    StandardEventsChangeProperties<V>;

--- a/packages/react/core/src/__tests__/useConnect-test.ts
+++ b/packages/react/core/src/__tests__/useConnect-test.ts
@@ -1,4 +1,4 @@
-import type { Wallet, WalletVersion } from '@wallet-standard/base';
+import type { Wallet } from '@wallet-standard/base';
 import { StandardConnect } from '@wallet-standard/features';
 import type { UiWallet } from '@wallet-standard/ui';
 import { getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } from '@wallet-standard/ui-registry';
@@ -23,7 +23,7 @@ describe('useConnect', () => {
             },
             icon: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEAAAAALAAAAAABAAEAAAIBAAA=',
             name: 'Mock Wallet',
-            version: '1.0.0' as WalletVersion,
+            version: '1.0.0',
         };
         jest.mocked(getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED).mockReturnValue(mockWallet);
         // Suppresses console output when an `ErrorBoundary` is hit.

--- a/packages/react/core/src/__tests__/useDisconnect-test.ts
+++ b/packages/react/core/src/__tests__/useDisconnect-test.ts
@@ -1,4 +1,4 @@
-import type { Wallet, WalletVersion } from '@wallet-standard/base';
+import type { Wallet } from '@wallet-standard/base';
 import { StandardDisconnect } from '@wallet-standard/features';
 import type { UiWallet } from '@wallet-standard/ui';
 import { getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } from '@wallet-standard/ui-registry';
@@ -23,7 +23,7 @@ describe('useDisconnect', () => {
             },
             icon: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEAAAAALAAAAAABAAEAAAIBAAA=',
             name: 'Mock Wallet',
-            version: '1.0.0' as WalletVersion,
+            version: '1.0.0',
         };
         jest.mocked(getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED).mockReturnValue(mockWallet);
         // Suppresses console output when an `ErrorBoundary` is hit.

--- a/packages/react/core/src/__tests__/useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT-test.ts
+++ b/packages/react/core/src/__tests__/useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT-test.ts
@@ -1,5 +1,5 @@
 import { getWallets } from '@wallet-standard/app';
-import type { Wallet, WalletVersion, WalletWithFeatures } from '@wallet-standard/base';
+import type { Wallet, WalletWithFeatures } from '@wallet-standard/base';
 import { StandardEvents, type StandardEventsFeature, type StandardEventsListeners } from '@wallet-standard/features';
 import { act } from 'react-test-renderer';
 
@@ -107,7 +107,7 @@ describe('useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT', () => {
             features: {
                 [StandardEvents]: {
                     on: () => mockStandardEventsDispose,
-                    version: '1.0.0' as WalletVersion,
+                    version: '1.0.0',
                 } as StandardEventsFeature['standard:events'],
             },
         } as unknown as Wallet;
@@ -164,7 +164,7 @@ describe('useWallets_INTERNAL_ONLY_NOT_FOR_EXPORT', () => {
                 } as StandardEventsFeature,
                 icon: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEAAAAALAAAAAABAAEAAAIBAAA=',
                 name: 'Mock Wallet',
-                version: '1.0.0' as WalletVersion,
+                version: '1.0.0',
             } as const,
         ];
         mockGet.mockReturnValue(mockWallets);

--- a/packages/react/core/src/features/version.ts
+++ b/packages/react/core/src/features/version.ts
@@ -1,3 +1,3 @@
 import type { WalletVersion } from '@wallet-standard/base';
 
-export const FEATURE_HOOKS_SUPPORTED_WALLET_VERSION = '1.0.0' as WalletVersion;
+export const FEATURE_HOOKS_SUPPORTED_WALLET_VERSION: WalletVersion = '1.0.0';

--- a/packages/ui/compare/src/__tests__/compare-test.ts
+++ b/packages/ui/compare/src/__tests__/compare-test.ts
@@ -1,5 +1,5 @@
-import type { Wallet, WalletAccount, WalletVersion } from '@wallet-standard/base';
-import type { UiWalletAccount, UiWallet } from '@wallet-standard/ui-core';
+import type { Wallet, WalletAccount } from '@wallet-standard/base';
+import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui-core';
 import {
     getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
     getOrCreateUiWalletForStandardWallet_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
@@ -24,7 +24,7 @@ describe('uiWalletAccountsAreSame()', () => {
             features: {},
             icon: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEAAAAALAAAAAABAAEAAAIBAAA=',
             name: 'Mock:Wallet',
-            version: '1.0.0' as WalletVersion,
+            version: '1.0.0',
         };
         mockUiWalletAccount = getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(
             mockWallet,
@@ -78,7 +78,7 @@ describe('uiWalletAccountBelongsToUiWallet()', () => {
             features: {},
             icon: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEAAAAALAAAAAABAAEAAAIBAAA=',
             name: 'Mock:Wallet',
-            version: '1.0.0' as WalletVersion,
+            version: '1.0.0',
         };
         mockUiWalletAccount = getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(
             mockWallet,

--- a/packages/ui/compare/src/__tests__/storage-key-test.ts
+++ b/packages/ui/compare/src/__tests__/storage-key-test.ts
@@ -1,4 +1,4 @@
-import type { Wallet, WalletVersion } from '@wallet-standard/base';
+import type { Wallet } from '@wallet-standard/base';
 import type { UiWalletAccount } from '@wallet-standard/ui-core';
 import { getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } from '@wallet-standard/ui-registry';
 
@@ -19,7 +19,7 @@ describe('getUiWalletAccountStorageKey()', () => {
             features: {},
             icon: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEAAAAALAAAAAABAAEAAAIBAAA=',
             name: 'Mock:Wallet',
-            version: '1.0.0' as WalletVersion,
+            version: '1.0.0',
         };
         mockUiWalletAccount = getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(
             mockWallet,

--- a/packages/ui/features/src/__tests__/getWalletFeature-test.ts
+++ b/packages/ui/features/src/__tests__/getWalletFeature-test.ts
@@ -1,4 +1,4 @@
-import type { Wallet, WalletVersion } from '@wallet-standard/base';
+import type { Wallet } from '@wallet-standard/base';
 import {
     WALLET_STANDARD_ERROR__FEATURES__WALLET_FEATURE_UNIMPLEMENTED,
     WalletStandardError,
@@ -24,7 +24,7 @@ describe('getWalletFeature', () => {
             },
             icon: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEAAAAALAAAAAABAAEAAAIBAAA=',
             name: 'Mock Wallet',
-            version: '1.0.0' as WalletVersion,
+            version: '1.0.0',
         };
         mockWalletHandle = {
             '~uiWalletHandle': Symbol(),

--- a/packages/ui/registry/src/__tests__/uiWalletRegistry_DO_NOT_USE_OR_YOU_WILL_BE_FIRED-test.ts
+++ b/packages/ui/registry/src/__tests__/uiWalletRegistry_DO_NOT_USE_OR_YOU_WILL_BE_FIRED-test.ts
@@ -1,6 +1,6 @@
 import '@wallet-standard/test-matchers/toBeFrozenObject';
 
-import type { Wallet, WalletAccount, WalletVersion } from '@wallet-standard/base';
+import type { Wallet, WalletAccount, WalletVersion1_0_0 } from '@wallet-standard/base';
 import type { UiWalletAccount } from '@wallet-standard/ui-core';
 
 import { getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } from '../UiWalletAccountRegistry_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.js';
@@ -182,7 +182,7 @@ describe('getOrCreateUiWalletForWalletHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED', (
     });
     it('returns a new UI wallet given the same underlying Standard wallet whose version has been mutated', () => {
         const uiWalletA = getOrCreateUiWalletForStandardWallet_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(mockWallet);
-        mockWallet.version = '2.0.0' as WalletVersion;
+        mockWallet.version = '1000.0.0' as WalletVersion1_0_0;
         const uiWalletB = getOrCreateUiWalletForStandardWallet_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(mockWallet);
         expect(uiWalletB).not.toBe(uiWalletA);
         expect(registerWalletHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED).toHaveBeenCalledWith(uiWalletB, mockWallet);


### PR DESCRIPTION
This proposes v1.1.0 of the Wallet Standard and v1.1.0 of the `standard:connect` feature:

- `WalletIcon` now supports HTTP/S URLs
- The `standard:connect` feature now supports filtering addresses, chains, and features.

Unfortunately the packages have already been released as 1.1.x on NPM, but I think the NPM package version will just be different than the version of the Standard or individual features for various reasons (one feature can change versions without the others changing).

This incorporates the changes in https://github.com/wallet-standard/wallet-standard/pull/105 and attempts to come up with a sane way to version the changes without breaking anything. I'm not sure if it'll actually work for some of the reasons proposed in #105, and because it would require a generic version to get passed around by things like `useConnect`, which has not been added yet (since it just defaults to v1.0.0).