### PR TITLE
[ui-registry] fix edge case where `UiWalletAccount`s don't maintain referential equality

### DIFF
--- a/.changeset/solid-seals-peel.md
+++ b/.changeset/solid-seals-peel.md
@@ -1,0 +1,5 @@
+---
+'@wallet-standard/ui-registry': patch
+---
+
+Fix `UiWalletAccount` handle not maintaining referential equality for underlying `ReadonlyWalletAccount`

--- a/packages/ui/registry/src/UiWalletAccountRegistry_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ts
+++ b/packages/ui/registry/src/UiWalletAccountRegistry_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ts
@@ -5,7 +5,7 @@ import {
     getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
     registerWalletHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
 } from './UiWalletHandleRegistry_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.js';
-import { identifierArraysAreDifferent } from './compare.js';
+import { byteArraysAreDifferent, identifierArraysAreDifferent } from './compare.js';
 
 const walletAccountsToUiWalletAccounts = new WeakMap<WalletAccount, UiWalletAccount>();
 
@@ -55,7 +55,7 @@ export function getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR
         uiWalletAccount.address !== account.address ||
         uiWalletAccount.icon !== account.icon ||
         uiWalletAccount.label !== account.label ||
-        uiWalletAccount.publicKey !== account.publicKey
+        byteArraysAreDifferent(uiWalletAccount.publicKey, account.publicKey)
     ) {
         dirtyUiWallet();
         uiWalletAccount.address = account.address;

--- a/packages/ui/registry/src/__tests__/uiWalletAccountRegistry_DO_NOT_USE_OR_YOU_WILL_BE_FIRED-test.ts
+++ b/packages/ui/registry/src/__tests__/uiWalletAccountRegistry_DO_NOT_USE_OR_YOU_WILL_BE_FIRED-test.ts
@@ -256,7 +256,7 @@ describe('getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_W
         );
         expect(uiWalletAccount).toHaveProperty('publicKey', mockWalletAccount.publicKey);
     });
-    it('returns a new UI wallet account given the same underlying Standard wallet account whose label has been mutated', () => {
+    it('returns a new UI wallet account given the same underlying Standard wallet account whose public key has been mutated', () => {
         const uiWalletAccountA = getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(
             mockWallet,
             mockWalletAccount
@@ -268,5 +268,19 @@ describe('getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_W
         );
         expect(uiWalletAccountB).not.toBe(uiWalletAccountA);
         expect(registerWalletHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED).toHaveBeenCalledWith(uiWalletAccountB, mockWallet);
+    });
+    it('returns the same UI wallet account given the same underlying Standard wallet account whose public key is referentially different', () => {
+        jest.mocked(getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED).mockReturnValue(mockWallet);
+
+        const uiWalletAccountA = getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(
+            mockWallet,
+            mockWalletAccount
+        );
+        mockWalletAccount.publicKey = mockWalletAccount.publicKey.slice();
+        const uiWalletAccountB = getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(
+            mockWallet,
+            mockWalletAccount
+        );
+        expect(uiWalletAccountB).toBe(uiWalletAccountA);
     });
 });

--- a/packages/ui/registry/src/compare.ts
+++ b/packages/ui/registry/src/compare.ts
@@ -1,4 +1,4 @@
-import type { IdentifierArray } from '@wallet-standard/base';
+import type { IdentifierArray, ReadonlyUint8Array } from '@wallet-standard/base';
 
 export function identifierArraysAreDifferent(a: IdentifierArray, b: IdentifierArray): boolean {
     // NOTE: Do not optimize this with an `a.length !== b.length` check. A length check does not
@@ -13,5 +13,19 @@ export function identifierArraysAreDifferent(a: IdentifierArray, b: IdentifierAr
             return true;
         }
     }
+    return false;
+}
+
+export function byteArraysAreDifferent(a: ReadonlyUint8Array, b: ReadonlyUint8Array): boolean {
+    if (a.length !== b.length) {
+        return true;
+    }
+
+    for (let i = 0; i < a.length; i += 1) {
+        if (a[i] !== b[i]) {
+            return true;
+        }
+    }
+
     return false;
 }


### PR DESCRIPTION
Readonly wallet accounts have getters that return a copy of the public key, features, and chains. This is problematic because the check for comparing two wallet accounts' public keys uses referential equality instead of structural equality. To fix this, we can simply compare the contents of the array similar to how we check for the chains and features changing.

Test plan
----
- The automated test fails on `main` and passes with this tweak 