### PR TITLE
relax node 22 engine pins

### DIFF
--- a/.changeset/relax-node-engine-pins.md
+++ b/.changeset/relax-node-engine-pins.md
@@ -1,0 +1,22 @@
+---
+"@wallet-standard/app": patch
+"@wallet-standard/base": patch
+"@wallet-standard/core": patch
+"@wallet-standard/errors": patch
+"@wallet-standard/ethereum": patch
+"@wallet-standard/ethereum-chains": patch
+"@wallet-standard/experimental": patch
+"@wallet-standard/experimental-features": patch
+"@wallet-standard/features": patch
+"@wallet-standard/react": patch
+"@wallet-standard/react-core": patch
+"@wallet-standard/ui": patch
+"@wallet-standard/ui-compare": patch
+"@wallet-standard/ui-core": patch
+"@wallet-standard/ui-features": patch
+"@wallet-standard/ui-registry": patch
+"@wallet-standard/wallet": patch
+"wallet-standard": patch
+---
+
+Relax Node engine constraints from exact Node 22 to Node 22 or newer.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "repository": "https://github.com/wallet-standard/wallet-standard",
     "license": "Apache-2.0",
     "engines": {
-        "node": "22",
+        "node": ">=22",
         "pnpm": "10.8.1"
     },
     "packageManager": "pnpm@10.8.1",

--- a/packages/_/_/package.json
+++ b/packages/_/_/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/core/_/package.json
+++ b/packages/core/_/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/core/app/package.json
+++ b/packages/core/app/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/core/errors/package.json
+++ b/packages/core/errors/package.json
@@ -14,7 +14,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/core/wallet/package.json
+++ b/packages/core/wallet/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/ethereum/_/package.json
+++ b/packages/ethereum/_/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/ethereum/chains/package.json
+++ b/packages/ethereum/chains/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/example/eip1193/package.json
+++ b/packages/example/eip1193/package.json
@@ -6,7 +6,7 @@
     "repository": "https://github.com/wallet-standard/wallet-standard",
     "license": "Apache-2.0",
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/experimental/_/package.json
+++ b/packages/experimental/_/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/experimental/features/package.json
+++ b/packages/experimental/features/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/react/_/package.json
+++ b/packages/react/_/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/react/core/package.json
+++ b/packages/react/core/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/tmp/parcel-packager-webextension/package.json
+++ b/packages/tmp/parcel-packager-webextension/package.json
@@ -7,7 +7,7 @@
     "source": "src/WebExtensionPackager.js",
     "main": "lib/WebExtensionPackager.js",
     "engines": {
-        "node": "22",
+        "node": ">=22",
         "parcel": "^2.14.4"
     },
     "scripts": {

--- a/packages/ui/_/package.json
+++ b/packages/ui/_/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/ui/compare/package.json
+++ b/packages/ui/compare/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/ui/core/package.json
+++ b/packages/ui/core/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/ui/features/package.json
+++ b/packages/ui/features/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,

--- a/packages/ui/registry/package.json
+++ b/packages/ui/registry/package.json
@@ -13,7 +13,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": "22"
+        "node": ">=22"
     },
     "type": "module",
     "sideEffects": false,


### PR DESCRIPTION
Replace exact Node 22 engine constraints with >=22 across the workspace packages so newer Node releases satisfy package metadata.

This relaxes the package-wide pin introduced by direct master commit 8418e7c5 ("use node 22 on all packages"), which has no associated PR and landed after the April 14, 2025 npm release.

Later package releases inherited the bad metadata, so keep Node 22 as the minimum without pretending only exactly Node 22 is valid.


Error I got:
```
Scope: all 20 workspace projects
Progress: resolved 0, reused 1, downloaded 0, added 0

/Users/beeman/dev/wallet-ui/wallet-ui/packages/react:
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

This error happened while installing a direct dependency of /Users/beeman/dev/wallet-ui/wallet-ui/packages/react

Your Node version is incompatible with "@wallet-standard/ui-registry@1.1.0".

Expected version: 22
Got: v24.5.0

This is happening because the package's manifest has an engines.node field specified.
To fix this issue, install the required Node version.
```